### PR TITLE
修复（JS）：Jint会忽略大小写

### DIFF
--- a/src/Application.Console/scripts/reactor/3008000.js
+++ b/src/Application.Console/scripts/reactor/3008000.js
@@ -8,7 +8,7 @@
 function hit() {
     var players = rm.getMap().getAllPlayers().toArray();
 
-    for (var i = 0; i < players.Length; i++) {
+    for (var i = 0; i < players.length; i++) {
         rm.giveCharacterExp(52000, players[i]);
     }
 }

--- a/src/Application.Core/Compatible/Extensions/JsEngineExtensions.cs
+++ b/src/Application.Core/Compatible/Extensions/JsEngineExtensions.cs
@@ -13,6 +13,8 @@
             var objType = list.GetType();
             if (objType.IsGenericType && objType.GetGenericTypeDefinition() == typeof(List<>))
                 return (int)objType.GetProperty("Count")!.GetValue(list)!;
+            if (objType.IsArray && list is Array arr)
+                return arr.Length;
             return 0;
         }
 
@@ -30,6 +32,10 @@
                         return indexer.GetValue(list, new object[] { index });
                     }
                 }
+            }
+            if (objType.IsArray && list is Array arr)
+            {
+                return arr.GetValue(index);
             }
             return null;
         }

--- a/src/Application.Core/Compatible/Extensions/ListExtensions.cs
+++ b/src/Application.Core/Compatible/Extensions/ListExtensions.cs
@@ -18,19 +18,5 @@
         {
             return list[index];
         }
-
-
-
-        /// <summary>
-        /// 兼容js
-        /// 不使用ToArray的原因：传入到js用的List，统一使用List
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="list"></param>
-        /// <returns></returns>
-        public static List<T> toArray<T>(this List<T> list)
-        {
-            return list.ToList();
-        }
     }
 }


### PR DESCRIPTION
toArray实际上调用的是ToArray，也无需使用Length。相关的Size，Get需要对数组进行处理

#8