### PR TITLE
修复：无意义的自定义对比引发bug

### DIFF
--- a/src/Application.Core/client/BuffStat.cs
+++ b/src/Application.Core/client/BuffStat.cs
@@ -126,16 +126,10 @@ public class BuffStat : EnumClass
     private long i;
     private bool isFirst;
 
-    BuffStat(long i, bool isFirst)
+    BuffStat(long i, bool isFirst = false)
     {
         this.i = i;
         this.isFirst = isFirst;
-    }
-
-    BuffStat(long i)
-    {
-        this.i = i;
-        this.isFirst = false;
     }
 
     public long getValue()
@@ -149,39 +143,6 @@ public class BuffStat : EnumClass
     public override string ToString()
     {
         return name();
-    }
-    public override bool Equals(object? obj)
-    {
-        if (obj is BuffStat m)
-            return this.i == m.i;
-        return false;
-    }
-
-    public static bool operator ==(BuffStat? obj1, BuffStat? obj2)
-    {
-        if (obj1 is null && obj2 is null)
-            return true;
-
-        if (obj1 is null)
-            return false;
-
-        return obj1.Equals(obj2);
-    }
-
-    public static bool operator !=(BuffStat? obj1, BuffStat? obj2)
-    {
-        return !(obj1 == obj2);
-    }
-
-
-    public override int GetHashCode()
-    {
-        // 将ulong拆分成高32位和低32位
-        uint lower = (uint)(i & 0xFFFFFFFF);
-        uint upper = (uint)(i >> 32);
-
-        // 组合高32位和低32位
-        return (int)(lower ^ upper);
     }
 
     public int CompareTo(BuffStat? other)


### PR DESCRIPTION
fix #62 
此处的自定义对比，导致 魔法铠甲 提供的buff `BuffStat WDEF = new BuffStat(0x200000000L)`和`BuffStat SLOW = new BuffStat(0x200000000L, true)`被视作相等，导致`player.getBuffedValue(BuffStat.SLOW) != null`